### PR TITLE
Ante fix for SCInvState nonterminal 

### DIFF
--- a/src/main/grammars/de/monticore/SCStateInvariants.mc4
+++ b/src/main/grammars/de/monticore/SCStateInvariants.mc4
@@ -28,6 +28,6 @@ component grammar SCStateInvariants extends SCBasis {
   /**
     States with a body allow to add State Invariants
   */
-  SCInvState extends SCState =  SCModifier "state" Name "[" Expression "]" SCSBody ";";
+  SCInvState extends SCState =  SCModifier SCSAnte "state" Name "[" Expression "]" SCSBody ";";
 
 }

--- a/src/test/java/de/monticore/cocos/InvariantValidTest.java
+++ b/src/test/java/de/monticore/cocos/InvariantValidTest.java
@@ -120,4 +120,17 @@ public class InvariantValidTest extends GeneralAbstractTest {
     assertEquals(0, Log.getErrorCount());
 
   }
+
+  @Test
+  public void testCoCoValid4() throws IOException {
+    Optional<ASTSCArtifact> ast = parser.parse("src/test/resources/valid/InvariantWithAnte.sc");
+    assertTrue("InvariantWithAnte.sc could not be parsed",  ast.isPresent());
+
+    IUMLStatechartsArtifactScope st = new UMLStatechartsTool().createSymbolTable(ast.get());
+    st.setName("InvariantWithAnte");
+    UMLStatechartsCoCoChecker checker = new UMLStatechartsCoCoChecker();
+    checker.addCoCo(new InvariantValid(new TypeCalculator(null, new FullUMLStatechartsDeriver())));
+    checker.checkAll(ast.get());
+    assertEquals(0, Log.getErrorCount());;
+  }
 }

--- a/src/test/java/de/monticore/parser/SCStateInvariantsParserPPTest.java
+++ b/src/test/java/de/monticore/parser/SCStateInvariantsParserPPTest.java
@@ -39,4 +39,15 @@ public class SCStateInvariantsParserPPTest extends GeneralAbstractTest {
     assertTrue("AST not equal after pp: " + pp, astPP.get().deepEquals(ast.get()));
   }
 
+  @Test
+  public void testSCStateInvariantWithAnte() throws IOException {
+    Optional<ASTSCInvState> ast = parser.parse_StringSCInvState("initial { System.out.println(\"Ante allowed here\"); } state Foo [ true && !false];");
+    TestUtils.check(parser);
+    assertTrue("No ast present", ast.isPresent());
+
+    String pp = new UMLStatechartsFullPrettyPrinter(new IndentPrinter()).prettyprint(ast.get());
+    Optional<ASTSCInvState> astPP = parser.parse_StringSCInvState(pp);
+    assertTrue("Failed to parse from pp: " + pp, astPP.isPresent());
+    assertTrue("AST not equal after pp: " + pp, astPP.get().deepEquals(ast.get()));
+  }
 }

--- a/src/test/resources/valid/InvariantWithAnte.sc
+++ b/src/test/resources/valid/InvariantWithAnte.sc
@@ -1,0 +1,4 @@
+/* (c) https://github.com/MontiCore/monticore */
+statechart InvariantWithAnte {
+  initial { System.out.println("Ante allowed here"); } state Foo [true];
+}


### PR DESCRIPTION
Using invariants as part of a state declaration without introducing SCSAnte results in a NullPointerException.