### PR TITLE
Use MCStatement in TransitionAction

### DIFF
--- a/src/main/grammars/de/monticore/SCTransitions4Code.mc4
+++ b/src/main/grammars/de/monticore/SCTransitions4Code.mc4
@@ -65,7 +65,7 @@ component grammar SCTransitions4Code
    * All actions are imperative
    */
   TransitionAction implements SCABody =
-    MCBlockStatement? ;
+    MCStatement? ;
 
   //***********************************************************
   // Ante Actions

--- a/src/main/java/de/monticore/sc2cd/SC2CDTriggeredTransitionVisitor.java
+++ b/src/main/java/de/monticore/sc2cd/SC2CDTriggeredTransitionVisitor.java
@@ -68,7 +68,7 @@ public class SC2CDTriggeredTransitionVisitor extends SC2CDTransitionVisitor
     // Print the action using the TriggeredStatechartsFullPrettyPrinter
     String action = "/* no action */";
     if (transitionBody.get().isPresentTransitionAction() && transitionBody.get().getTransitionAction()
-      .isPresentMCBlockStatement()) {
+      .isPresentMCStatement()) {
       action = (new TriggeredStatechartsFullPrettyPrinter(new IndentPrinter())).prettyprint(transitionBody.get().getTransitionAction());
     }
     // Print the precondition as an expression, too

--- a/src/main/java/de/monticore/sc2cd/SC2CDUMLTransitionVisitor.java
+++ b/src/main/java/de/monticore/sc2cd/SC2CDUMLTransitionVisitor.java
@@ -53,7 +53,7 @@ public class SC2CDUMLTransitionVisitor extends SC2CDTransitionVisitor
     // Print the action using the UMLStatechartsFullPrettyPrinter
     String action = "/* no action */";
     if (transitionBody.get().isPresentTransitionAction() && transitionBody.get().getTransitionAction()
-            .isPresentMCBlockStatement()) {
+            .isPresentMCStatement()) {
       IndentPrinter printer = new IndentPrinter();
       new UMLStatechartsFullPrettyPrinter(printer).getTraverser().handle(transitionBody.get().getTransitionAction());
       action = printer.getContent();


### PR DESCRIPTION
This makes it impossible to declare new variables without a block statement.

I.e. fixes:
```
automaton {
    initial state S;
    S -> S / int i = 0;;
    S -> S / { i = 1; };
}
```