### PR TITLE
Adjusted TransitionPreconditionsAreBoolean

### DIFF
--- a/src/main/java/de/monticore/sctransitions4code/_cocos/TransitionPreconditionsAreBoolean.java
+++ b/src/main/java/de/monticore/sctransitions4code/_cocos/TransitionPreconditionsAreBoolean.java
@@ -46,7 +46,7 @@ public class TransitionPreconditionsAreBoolean implements SCTransitions4CodeASTT
       }
       if (!SymTypeRelations.isBoolean(preType)) {
         Log.error(String.format(ERROR_CODE + " " + MESSAGE, preType.print()),
-          node.get_SourcePositionStart(), node.get_SourcePositionEnd()
+          node.getPre().get_SourcePositionStart(), node.getPre().get_SourcePositionEnd()
         );
       }
     }

--- a/src/main/java/de/monticore/sctransitions4code/_cocos/TransitionPreconditionsAreBoolean.java
+++ b/src/main/java/de/monticore/sctransitions4code/_cocos/TransitionPreconditionsAreBoolean.java
@@ -32,18 +32,20 @@ public class TransitionPreconditionsAreBoolean implements SCTransitions4CodeASTT
     this.typeDeriver = typeDeriver;
   }
 
-  public TransitionPreconditionsAreBoolean() { this(null); }
+  public TransitionPreconditionsAreBoolean() {
+    this(null);
+  }
 
   @Override
   public void check(ASTTransitionBody node) {
-    if(node.isPresentPre()) {
+    if (node.isPresentPre()) {
       SymTypeExpression preType = TypeCheck3.typeOf(node.getPre());
       if (preType.isObscureType()) {
         Log.debug(String.format("Coco '%s' is not checked on transition guard expression at %s, because the " +
           "expression is malformed.", this.getClass().getSimpleName(), node.get_SourcePositionStart()), "Cocos");
-      } else if(!SymTypeRelations.isBoolean(preType)) {
-        Log.error(
-          String.format(ERROR_CODE + " " + MESSAGE, preType.print()),
+      }
+      if (!SymTypeRelations.isBoolean(preType)) {
+        Log.error(String.format(ERROR_CODE + " " + MESSAGE, preType.print()),
           node.get_SourcePositionStart(), node.get_SourcePositionEnd()
         );
       }

--- a/src/test/java/de/monticore/cocos/TransitionPreconditionsAreBooleanTest.java
+++ b/src/test/java/de/monticore/cocos/TransitionPreconditionsAreBooleanTest.java
@@ -101,7 +101,7 @@ public class TransitionPreconditionsAreBooleanTest extends GeneralAbstractTest {
       .map(finding -> finding.getMsg().substring(0, "0xFD118".length()))
       .collect(Collectors.toList());
 
-    assertEquals(Lists.newArrayList("0xFD118"), findings);
+    assertEquals(Lists.newArrayList("0xFD118", "0xCC111"), findings);
   }
 
   @Test
@@ -117,8 +117,11 @@ public class TransitionPreconditionsAreBooleanTest extends GeneralAbstractTest {
     checker.checkAll(ast);
 
     // Then
-    assertEquals(1, Log.getFindingsCount());
-    // Only print the error that the variable symbol can not be found:
-    assertEquals("0xFD118", Log.getFindings().get(0).getMsg().substring(0, 7));
+    List<String> findings = Log.getFindings().stream()
+      .filter(Finding::isError)
+      .map(finding -> finding.getMsg().substring(0, "0xFD118".length()))
+      .collect(Collectors.toList());
+
+    assertEquals(Lists.newArrayList("0xFD118", "0xCC111"), findings);
   }
 }


### PR DESCRIPTION
Changed the 'else if' query to a separate 'if' query to also throw an error when the precondition is not a boolean, despite being an obscure type.