### PR TITLE
4835 improve error handling with guava

### DIFF
--- a/src/main/java/de/monticore/triggeredstatecharts/_symboltable/TriggeredStatechartsScopesGenitor.java
+++ b/src/main/java/de/monticore/triggeredstatecharts/_symboltable/TriggeredStatechartsScopesGenitor.java
@@ -1,5 +1,6 @@
 package de.monticore.triggeredstatecharts._symboltable;
 
+import com.google.common.base.Preconditions;
 import de.monticore.scbasis._ast.ASTSCArtifact;
 import de.monticore.symboltable.ImportStatement;
 import de.monticore.triggeredstatecharts.TriggeredStatechartsMill;
@@ -12,7 +13,7 @@ import java.util.List;
 
 public class TriggeredStatechartsScopesGenitor extends TriggeredStatechartsScopesGenitorTOP {
     public ITriggeredStatechartsArtifactScope createFromAST(ASTSCArtifact rootNode){
-      Log.errorIfNull(rootNode, "0xAE880 Internal Error: No symbol table defined, because empty (null) AST");
+      Preconditions.checkNotNull(rootNode, "0xAE880 Internal Error: No symbol table defined, because empty (null) AST");
       ITriggeredStatechartsArtifactScope artifactScope = TriggeredStatechartsMill.artifactScope();
       if(rootNode.isPresentPackage()) {
         artifactScope.setPackageName(rootNode.getPackage().getQName());

--- a/src/main/java/de/monticore/umlstatecharts/_symboltable/UMLStatechartsScopesGenitor.java
+++ b/src/main/java/de/monticore/umlstatecharts/_symboltable/UMLStatechartsScopesGenitor.java
@@ -1,6 +1,7 @@
 /* (c) https://github.com/MontiCore/monticore */
 package de.monticore.umlstatecharts._symboltable;
 
+import com.google.common.base.Preconditions;
 import de.monticore.scbasis._ast.ASTSCArtifact;
 import de.monticore.symboltable.ImportStatement;
 import de.monticore.types.mcbasictypes._ast.ASTMCImportStatement;
@@ -21,7 +22,7 @@ public class UMLStatechartsScopesGenitor extends UMLStatechartsScopesGenitorTOP 
    */
   @Override
   public IUMLStatechartsArtifactScope createFromAST(ASTSCArtifact rootNode) {
-    Log.errorIfNull(rootNode, "0xAE880 Internal Error: No symbol table defined, because empty (null) AST");
+    Preconditions.checkNotNull(rootNode, "0xAE880 Internal Error: No symbol table defined, because empty (null) AST");
     IUMLStatechartsArtifactScope artifactScope = de.monticore.umlstatecharts.UMLStatechartsMill.artifactScope();
     if(rootNode.isPresentPackage()) {
       artifactScope.setPackageName(rootNode.getPackage().getQName());


### PR DESCRIPTION
Completed subtasks:
 -  Log::errorIfNull should be deprecated and replaced
 -  Objects::requireNonNull should be replaced as well (technically not part of the Logging issue, but related)

There are still open subtasks in in issue #4835
